### PR TITLE
fix: trust CREATED statusCode for ProBuddy signup; drop deprecated id…

### DIFF
--- a/src/api/pro-buddies.ts
+++ b/src/api/pro-buddies.ts
@@ -187,6 +187,11 @@ export const registerProBuddy = async (payload: any) => {
 
   const data = await response.json();
   if (!response.ok) throw new Error(data.message || data.error || "Failed to register ProBuddy");
+  // Success is decided by the response body, not the HTTP status (may be 200).
+  // Only treat registration as successful when statusCode is "CREATED".
+  if (data?.statusCode !== "CREATED") {
+    throw new Error(data?.message || data?.error || "Failed to register ProBuddy");
+  }
   return data;
 };
 
@@ -305,7 +310,7 @@ export const uploadProBuddyIdCardPhoto = async (proBuddyId: string, photo: File)
   formData.append("photo", photo);
 
   const response = await fetch(
-    buildApiUrl(API_CONFIG.endpoints.proBuddyUploadIdCardPhoto, { proBuddyId }),
+    `${API_CONFIG.baseUrl}${API_CONFIG.endpoints.proBuddyUploadIdCardPhoto}`,
     {
     method: "POST",
     headers: {


### PR DESCRIPTION
… param on ID card upload

- registerProBuddy now treats registration as successful only when the response body has statusCode === "CREATED" (HTTP may be 200 on failure)
- uploadProBuddyIdCardPhoto sends proBuddyId only in the body, not the deprecated query param